### PR TITLE
Included branch main in cargo generate statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Use cargo generate to create a new actor module from this template:
 
 ```
-cargo generate --git https://github.com/wasmCloud/new-actor-template
+cargo generate --git https://github.com/wasmCloud/new-actor-template --branch main
 ```
 
 Use the `wash` CLI to sign your WebAssembly module after you have created it. The `Makefile` created by this template will sign your module for you with `make build` and `make release`.


### PR DESCRIPTION
Because our default branch is `main` instead of what `cargo generate` expects (`master`) the default `cargo generate` command will fail. Adding the `--branch` argument will allow the README example code to successfully generate.