### PR TITLE
Remove extern keyword and extend Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,16 @@ clean:
 doc:
 	@$(CARGO) doc
 
+inspect:
+	wash claims inspect $(RELEASE)/{{crate_name}}_s.wasm
+
+release:
+	@$(CARGO) build --release	
+	wash claims sign $(RELEASE)/{{crate_name}}.wasm -c wasmcloud:httpserver --name "{{crate_name}}" --ver $(VERSION) --rev 0
+	wash claims inspect $(RELEASE)/{{crate_name}}_s.wasm
+
 test: build
 	@$(CARGO) test
 
 update:
 	@$(CARGO) update
-
-release:
-	@$(CARGO) build --release	
-	wash claims sign $(RELEASE)/{{crate_name}}.wasm -c wasmcloud:httpserver --name "{{crate_name}}" --ver $(VERSION) --rev 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate wapc_guest as guest;
+use wapc_guest as guest;
 use wasmcloud_actor_core as actor;
 
 use guest::prelude::*;


### PR DESCRIPTION
Inspect command is used quite often and it is one of the verbose commands that requires a lot of typing. Having it available saves substantial time.